### PR TITLE
Clean up main menu

### DIFF
--- a/next/components/header/header.tsx
+++ b/next/components/header/header.tsx
@@ -1,6 +1,6 @@
+import { useTranslation } from "next-i18next";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useTranslation } from "next-i18next";
 import { useState } from "react";
 
 import { MainMenu, MenuToggle } from "@/components/main-menu/main-menu";
@@ -8,30 +8,28 @@ import { Menu } from "@/lib/zod/menu";
 import SearchIcon from "@/styles/icons/search.svg";
 import WunderIcon from "@/styles/icons/wunder.svg";
 
-import { LanguageSwitcher } from "./language-switcher";
-import { UserMenu } from "./user-menu";
 import { MainMenuFull } from "../main-menu/main-menu-full";
+import { LanguageSwitcher } from "./language-switcher";
 
 interface HeaderProps {
   menu: Menu;
 }
 
 export function Header({ menu }: HeaderProps) {
-  
   const [isMainMenuOpen, setIsMainMenuOpen] = useState(false);
 
   return (
-    <header className="z-50 flex-shrink-0 border-b border-finnishwinter bg-primary-200 text-primary-600 md:sticky md:top-0">
+    <header className="z-50 flex-shrink-0 border-b border-finnishwinter bg-white text-primary-600 md:sticky md:top-0">
       <nav className="mx-auto flex max-w-6xl flex-row items-center justify-between px-6 py-4">
         <HomeLink />
         <div className="flex flex-row items-center justify-end gap-6 sm:gap-8">
-          <SearchLink />
           <div className="hidden lg:block">
-          <MainMenuFull menu={menu}></MainMenuFull>
+            <MainMenuFull menu={menu} />
           </div>
           <LanguageSwitcher />
+          <SearchLink />
           <div className="lg:hidden">
-          <MenuToggle isOpen={isMainMenuOpen} setIsOpen={setIsMainMenuOpen} />
+            <MenuToggle isOpen={isMainMenuOpen} setIsOpen={setIsMainMenuOpen} />
           </div>
         </div>
       </nav>
@@ -60,9 +58,7 @@ function SearchLink() {
   const { t } = useTranslation();
   return (
     <Link href="/search" locale={locale} className="hover:underline">
-      <span className="sr-only sm:not-sr-only sm:mr-2 sm:inline">
-        {t("search")}
-      </span>
+      <span className="sr-only">{t("search")}</span>
       <SearchIcon className="inline-block h-6 w-6" aria-hidden="true" />
     </Link>
   );

--- a/next/components/main-menu/main-menu-full.tsx
+++ b/next/components/main-menu/main-menu-full.tsx
@@ -35,7 +35,13 @@ export function MainMenuFull({ menu }: MainMenuFullProps) {
               aria-haspopup={
                 item.items && item.items.length > 0 ? "true" : "false"
               }
-              aria-expanded={visibleSubmenu === item.id ? "true" : "false"}
+              aria-expanded={
+                item.items &&
+                item.items.length > 0 &&
+                visibleSubmenu === item.id
+                  ? "true"
+                  : "false"
+              }
             >
               <Link href={item.url}>
                 <div className="flex flex-row items-center w-min mt-2 text-base text-left bg-transparent rounded-lg md:w-auto md:block md:mt-0 md:ml-4 focus:outline-none hover:underline">

--- a/next/components/main-menu/main-menu-full.tsx
+++ b/next/components/main-menu/main-menu-full.tsx
@@ -9,11 +9,11 @@ export function MainMenuFull({ menu }) {
       >
         {menu.map((item) => (
           <div className="relative group" key={item.id}>
-            <button className="flex flex-row items-center w-full px-4 py-4 mt-2 text-base text-left bg-transparent rounded-lg md:w-auto md:inline md:mt-0 md:ml-4 focus:outline-none font-montserrat hover:underline">
-              <Link href={item.url}>
+            <Link href={item.url}>
+              <button className="flex flex-row items-center w-full px-4 py-4 mt-2 text-base text-left bg-transparent rounded-lg md:w-auto md:inline md:mt-0 md:ml-4 focus:outline-none hover:underline">
                 <span>{item.title}</span>
-              </Link>
-            </button>
+              </button>
+            </Link>
             {item.items && item.items.length > 0 && (
               <div className="absolute z-10 hidden bg-primary-500 group-hover:block">
                 <div className="px-4 pt-2 pb-4 bg-white shadow-lg w-60">

--- a/next/components/main-menu/main-menu-full.tsx
+++ b/next/components/main-menu/main-menu-full.tsx
@@ -52,23 +52,21 @@ export function MainMenuFull({ menu }: MainMenuFullProps) {
                 <div
                   className={`absolute z-10 ${
                     visibleSubmenu === item.id ? "block" : "hidden"
-                  } bg-primary-500`}
+                  } px-4 pt-2 pb-4 bg-white shadow-lg w-50`}
                 >
-                  <div className="px-4 pt-2 pb-4 bg-white shadow-lg w-60">
-                    <ul className="grid grid-cols-1 gap-4">
-                      {item.items.map((subitem) => (
-                        <li key={subitem.id}>
-                          <Link
-                            href={subitem.url}
-                            className="hover:underline"
-                            onClick={() => setVisibleSubmenu(null)}
-                          >
-                            {subitem.title}
-                          </Link>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
+                  <ul className="grid grid-cols-1 gap-4">
+                    {item.items.map((subitem) => (
+                      <li key={subitem.id}>
+                        <Link
+                          href={subitem.url}
+                          className="hover:underline block"
+                          onClick={() => setVisibleSubmenu(null)}
+                        >
+                          {subitem.title}
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
                 </div>
               )}
             </li>

--- a/next/components/main-menu/main-menu-full.tsx
+++ b/next/components/main-menu/main-menu-full.tsx
@@ -1,27 +1,32 @@
-import NextLink from "next/link";
-export function MainMenuFull ({menu}){
+import Link from "next/link";
+export function MainMenuFull({ menu }) {
   return (
     <div>
-      <nav aria-label="primary" className="relative z-20 flex-col flex-grow hidden pb-4 md:pb-0 md:flex md:justify-end md:flex-row">
-  
-  {menu.map((item) =>
-    <div className="relative group">
-    <button className="flex flex-row items-center w-full px-4 py-4 mt-2 text-base font-bold text-left uppercase bg-transparent rounded-lg md:w-auto md:inline md:mt-0 md:ml-4 focus:outline-none font-montserrat hover:underline">
-    <NextLink href={item.url}><span>{item.title}</span></NextLink>
-    </button>
-    <div className="absolute z-10 hidden bg-primary-500 group-hover:block">
-        
-        <div className="px-4 pt-2 pb-4 bg-white shadow-lg w-40">
-          <div className="grid grid-cols-1 gap-4">
-            {item.items?.map((subitem) =>
-            <NextLink href={subitem.url}><li className="hover:underline">{subitem.title}</li></NextLink>
-            )}
+      <nav
+        aria-label="primary"
+        className="relative z-20 flex-col flex-grow hidden pb-4 md:pb-0 md:flex md:justify-end md:flex-row"
+      >
+        {menu.map((item) => (
+          <div className="relative group">
+            <button className="flex flex-row items-center w-full px-4 py-4 mt-2 text-base font-bold text-left uppercase bg-transparent rounded-lg md:w-auto md:inline md:mt-0 md:ml-4 focus:outline-none font-montserrat hover:underline">
+              <Link href={item.url}>
+                <span>{item.title}</span>
+              </Link>
+            </button>
+            <div className="absolute z-10 hidden bg-primary-500 group-hover:block">
+              <div className="px-4 pt-2 pb-4 bg-white shadow-lg w-40">
+                <div className="grid grid-cols-1 gap-4">
+                  {item.items?.map((subitem) => (
+                    <Link href={subitem.url}>
+                      <li className="hover:underline">{subitem.title}</li>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            </div>
           </div>
-        </div>
+        ))}
+      </nav>
     </div>
-</div>  
-  )} 
-</nav>
-    </div>
-  )
+  );
 }

--- a/next/components/main-menu/main-menu-full.tsx
+++ b/next/components/main-menu/main-menu-full.tsx
@@ -58,7 +58,11 @@ export function MainMenuFull({ menu }: MainMenuFullProps) {
                     <ul className="grid grid-cols-1 gap-4">
                       {item.items.map((subitem) => (
                         <li key={subitem.id}>
-                          <Link href={subitem.url} className="hover:underline">
+                          <Link
+                            href={subitem.url}
+                            className="hover:underline"
+                            onClick={() => setVisibleSubmenu(null)}
+                          >
                             {subitem.title}
                           </Link>
                         </li>

--- a/next/components/main-menu/main-menu-full.tsx
+++ b/next/components/main-menu/main-menu-full.tsx
@@ -8,22 +8,24 @@ export function MainMenuFull({ menu }) {
       >
         {menu.map((item) => (
           <div className="relative group">
-            <button className="flex flex-row items-center w-full px-4 py-4 mt-2 text-base font-bold text-left uppercase bg-transparent rounded-lg md:w-auto md:inline md:mt-0 md:ml-4 focus:outline-none font-montserrat hover:underline">
+            <button className="flex flex-row items-center w-full px-4 py-4 mt-2 text-base text-left bg-transparent rounded-lg md:w-auto md:inline md:mt-0 md:ml-4 focus:outline-none font-montserrat hover:underline">
               <Link href={item.url}>
                 <span>{item.title}</span>
               </Link>
             </button>
-            <div className="absolute z-10 hidden bg-primary-500 group-hover:block">
-              <div className="px-4 pt-2 pb-4 bg-white shadow-lg w-40">
-                <div className="grid grid-cols-1 gap-4">
-                  {item.items?.map((subitem) => (
-                    <Link href={subitem.url}>
-                      <li className="hover:underline">{subitem.title}</li>
-                    </Link>
-                  ))}
+            {item.items && item.items.length > 0 && (
+              <div className="absolute z-10 hidden bg-primary-500 group-hover:block">
+                <div className="px-4 pt-2 pb-4 bg-white shadow-lg w-40">
+                  <div className="grid grid-cols-1 gap-4">
+                    {item.items.map((subitem) => (
+                      <Link href={subitem.url}>
+                        <li className="hover:underline">{subitem.title}</li>
+                      </Link>
+                    ))}
+                  </div>
                 </div>
               </div>
-            </div>
+            )}
           </div>
         ))}
       </nav>

--- a/next/components/main-menu/main-menu-full.tsx
+++ b/next/components/main-menu/main-menu-full.tsx
@@ -32,6 +32,10 @@ export function MainMenuFull({ menu }: MainMenuFullProps) {
               key={item.id}
               onMouseEnter={() => handleMouseEnter(item.id)}
               onMouseLeave={handleMouseLeave}
+              aria-haspopup={
+                item.items && item.items.length > 0 ? "true" : "false"
+              }
+              aria-expanded={visibleSubmenu === item.id ? "true" : "false"}
             >
               <Link href={item.url}>
                 <div className="flex flex-row items-center w-min mt-2 text-base text-left bg-transparent rounded-lg md:w-auto md:block md:mt-0 md:ml-4 focus:outline-none hover:underline">

--- a/next/components/main-menu/main-menu-full.tsx
+++ b/next/components/main-menu/main-menu-full.tsx
@@ -16,11 +16,13 @@ export function MainMenuFull({ menu }) {
             </button>
             {item.items && item.items.length > 0 && (
               <div className="absolute z-10 hidden bg-primary-500 group-hover:block">
-                <div className="px-4 pt-2 pb-4 bg-white shadow-lg w-40">
+                <div className="px-4 pt-2 pb-4 bg-white shadow-lg w-60">
                   <div className="grid grid-cols-1 gap-4">
                     {item.items.map((subitem) => (
                       <Link href={subitem.url} key={subitem.id}>
-                        <li className="hover:underline">{subitem.title}</li>
+                        <li className="hover:underline list-none">
+                          {subitem.title}
+                        </li>
                       </Link>
                     ))}
                   </div>

--- a/next/components/main-menu/main-menu-full.tsx
+++ b/next/components/main-menu/main-menu-full.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+
 export function MainMenuFull({ menu }) {
   return (
     <div>
@@ -7,7 +8,7 @@ export function MainMenuFull({ menu }) {
         className="relative z-20 flex-col flex-grow hidden pb-4 md:pb-0 md:flex md:justify-end md:flex-row"
       >
         {menu.map((item) => (
-          <div className="relative group">
+          <div className="relative group" key={item.id}>
             <button className="flex flex-row items-center w-full px-4 py-4 mt-2 text-base text-left bg-transparent rounded-lg md:w-auto md:inline md:mt-0 md:ml-4 focus:outline-none font-montserrat hover:underline">
               <Link href={item.url}>
                 <span>{item.title}</span>
@@ -18,7 +19,7 @@ export function MainMenuFull({ menu }) {
                 <div className="px-4 pt-2 pb-4 bg-white shadow-lg w-40">
                   <div className="grid grid-cols-1 gap-4">
                     {item.items.map((subitem) => (
-                      <Link href={subitem.url}>
+                      <Link href={subitem.url} key={subitem.id}>
                         <li className="hover:underline">{subitem.title}</li>
                       </Link>
                     ))}

--- a/next/components/main-menu/main-menu-full.tsx
+++ b/next/components/main-menu/main-menu-full.tsx
@@ -1,36 +1,65 @@
+import { Menu } from "@/lib/zod/menu";
 import Link from "next/link";
+import { useState } from "react";
 
-export function MainMenuFull({ menu }) {
+interface MainMenuFullProps {
+  menu: Menu;
+}
+
+// Main menu with dropdowns for larger screens
+export function MainMenuFull({ menu }: MainMenuFullProps) {
+  // State to track the visibility of submenus
+  const [visibleSubmenu, setVisibleSubmenu] = useState<string | null>(null);
+
+  const handleMouseEnter = (itemId: string) => {
+    setVisibleSubmenu(itemId);
+  };
+
+  const handleMouseLeave = () => {
+    setVisibleSubmenu(null);
+  };
+
   return (
     <div>
       <nav
         aria-label="primary"
         className="relative z-20 flex-col flex-grow hidden pb-4 md:pb-0 md:flex md:justify-end md:flex-row"
       >
-        {menu.map((item) => (
-          <div className="relative group" key={item.id}>
-            <Link href={item.url}>
-              <button className="flex flex-row items-center w-full px-4 py-4 mt-2 text-base text-left bg-transparent rounded-lg md:w-auto md:inline md:mt-0 md:ml-4 focus:outline-none hover:underline">
-                <span>{item.title}</span>
-              </button>
-            </Link>
-            {item.items && item.items.length > 0 && (
-              <div className="absolute z-10 hidden bg-primary-500 group-hover:block">
-                <div className="px-4 pt-2 pb-4 bg-white shadow-lg w-60">
-                  <div className="grid grid-cols-1 gap-4">
-                    {item.items.map((subitem) => (
-                      <Link href={subitem.url} key={subitem.id}>
-                        <li className="hover:underline list-none">
-                          {subitem.title}
+        <ul className="flex flex-col md:flex-row">
+          {menu.map((item) => (
+            <li
+              className="relative group"
+              key={item.id}
+              onMouseEnter={() => handleMouseEnter(item.id)}
+              onMouseLeave={handleMouseLeave}
+            >
+              <Link href={item.url}>
+                <div className="flex flex-row items-center w-min mt-2 text-base text-left bg-transparent rounded-lg md:w-auto md:block md:mt-0 md:ml-4 focus:outline-none hover:underline">
+                  <span>{item.title}</span>
+                </div>
+              </Link>
+              {item.items && item.items.length > 0 && (
+                <div
+                  className={`absolute z-10 ${
+                    visibleSubmenu === item.id ? "block" : "hidden"
+                  } bg-primary-500`}
+                >
+                  <div className="px-4 pt-2 pb-4 bg-white shadow-lg w-60">
+                    <ul className="grid grid-cols-1 gap-4">
+                      {item.items.map((subitem) => (
+                        <li key={subitem.id}>
+                          <Link href={subitem.url} className="hover:underline">
+                            {subitem.title}
+                          </Link>
                         </li>
-                      </Link>
-                    ))}
+                      ))}
+                    </ul>
                   </div>
                 </div>
-              </div>
-            )}
-          </div>
-        ))}
+              )}
+            </li>
+          ))}
+        </ul>
       </nav>
     </div>
   );

--- a/next/components/main-menu/main-menu.tsx
+++ b/next/components/main-menu/main-menu.tsx
@@ -64,6 +64,15 @@ export function MainMenu({ menu, isOpen, setIsOpen }: MainMenuProps) {
   });
 
   useEffect(() => {
+    // Close menu when viewport is >= 1024px
+    const handleResize = () => {
+      if (window.innerWidth >= 1024) {
+        setIsOpen(false);
+      }
+    };
+
+    window.addEventListener("resize", handleResize);
+
     // Prevent body scroll when menu is open
     document.body.style.overflow = isOpen ? "hidden" : "auto";
 
@@ -107,6 +116,10 @@ export function MainMenu({ menu, isOpen, setIsOpen }: MainMenuProps) {
 
       setDidInit(true);
     }
+    // Clean up event listener on component unmount
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
   }, [isOpen, menu, router]);
 
   const activeMenuTitle = menu.find((i) => i.id === activeMenu)?.title;

--- a/next/next.config.js
+++ b/next/next.config.js
@@ -25,6 +25,9 @@ const nextConfig = {
     });
     return config;
   },
+  compiler: {
+    styledComponents: true,
+  },
 };
 
 module.exports = nextConfig;

--- a/next/next.config.js
+++ b/next/next.config.js
@@ -25,9 +25,6 @@ const nextConfig = {
     });
     return config;
   },
-  compiler: {
-    styledComponents: true,
-  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Link to ticket:

[Trello ticket](https://trello.com/c/WWvkamCE)

## Changes proposed in this PR:

This PR cleans up the main menu (MainMenuFull) with dropdowns in larger screens.

- Fixes the React console warning of _missing key_ by adding unique keys li items.
- Improves accessibility (contain li within a proper list element, add aria attributes aria-expanded and aria-haspopup dynamically)
- Improves usability (links are more easily clickable, dropdown closes/hides after clicking a link)
- Closes the opened menu for smaller screens on window resize >= 1024px to prevent overlap with other menus
- Renders dropdown only if there are submenu items
- Styling closer to what we have in prototype

## Notes:

- Functionality is there. More cleaner style (and indicators like arrowdown for expandable menu item) should be applied in the future. Maybe consider refactoring by using Radix UI's Navigation menu.

## Best practices:

<details>
<summary><h3>Accessibility:</h3></summary>
<p>
This project must support WCAG accessibility level AA <em>(edit this according to the requirements of your project)</em>. To ensure this standard is met, remember to:

- Perform automated checks using a tool such as Wave or SiteImprove.
- Test keyboard navigation: are all parts of the UI navigable using only the keyboard? Is the tab order logical? Can popups, menus etc be dismissed with the escape key?
- Test responsiveness, scaling and text reflow.
- Make sure no accessibility issues exist on either desktop or mobile views.
- If you have time, test with a screen reader such as VoiceOver (macOS), NVDA (Windows), or Orca (Linux).

Use the [Accessibility Testing Cheat Sheet](https://intra.wunder.io/info/accessibility-group/accessibility-testing-cheat-sheet) for information on how to run these tests.
</p>
</details>
