### PR TITLE
Breadcrumbs navigation

### DIFF
--- a/next/components/breadcrumb.tsx
+++ b/next/components/breadcrumb.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import React, { ReactNode } from 'react'
+
+import { usePathname } from 'next/navigation'
+import Link from 'next/link'
+
+type TBreadCrumbProps = {
+    homeElement: ReactNode,
+    separator: ReactNode,
+    containerClasses?: string,
+    listClasses?: string,
+    activeClasses?: string,
+    capitalizeLinks?: boolean
+}
+
+const Breadcrumb = ({homeElement, separator, containerClasses, listClasses, activeClasses, capitalizeLinks}: TBreadCrumbProps) => {
+
+    const paths = usePathname()
+    const pathNames = paths.split('/').filter( path => path )
+
+    return (
+        <div>
+            <ul className={containerClasses}>
+                <li className={listClasses}><Link href={'/'}>{homeElement}</Link></li>
+                {pathNames.length > 0 && separator}
+            {
+                pathNames.map( (link, index) => {
+                    let href = `/${pathNames.slice(0, index + 1).join('/')}`
+                    let itemClasses = paths === href ? `${listClasses} ${activeClasses}` : listClasses
+                    let itemLink = capitalizeLinks ? link[0].toUpperCase() + link.slice(1, link.length) : link
+                    return (
+                        <React.Fragment key={index}>
+                            <li className={itemClasses} >
+                                <Link href={href}>{itemLink}</Link>
+                            </li>
+                            {pathNames.length !== index + 1 && separator}
+                        </React.Fragment>
+                    )
+                })
+            }
+            </ul>
+        </div>
+    )
+}
+
+export default Breadcrumb

--- a/next/components/breadcrumb.tsx
+++ b/next/components/breadcrumb.tsx
@@ -19,15 +19,17 @@ const Breadcrumb = ({homeElement, separator, containerClasses, listClasses, acti
     const paths = usePathname()
     const pathNames = paths.split('/').filter( path => path )
 
+    const excludedPaths = ["/", "/404", "/500", "/careers"];
+
+    if (excludedPaths.includes(paths)) {
+      return null;
+  }
+
     return (
         <div>
             <ul className={containerClasses}>
-            {paths !== "/" && (
-                  <>
                     <li className={listClasses}><Link href={'/'}>{homeElement}</Link></li>
                     {pathNames.length > 0 && separator}
-                  </>
-                )}
                 {
                 pathNames.map( (link, index) => {
                     let href = `/${pathNames.slice(0, index + 1).join('/')}`

--- a/next/components/breadcrumb.tsx
+++ b/next/components/breadcrumb.tsx
@@ -19,7 +19,7 @@ const Breadcrumb = ({homeElement, separator, containerClasses, listClasses, acti
     const paths = usePathname()
     const pathNames = paths.split('/').filter( path => path )
 
-    const excludedPaths = ["/", "/404", "/500", "/careers"];
+    const excludedPaths = ["/", "/404", "/500"];
 
     if (excludedPaths.includes(paths)) {
       return null;

--- a/next/components/breadcrumb.tsx
+++ b/next/components/breadcrumb.tsx
@@ -22,9 +22,13 @@ const Breadcrumb = ({homeElement, separator, containerClasses, listClasses, acti
     return (
         <div>
             <ul className={containerClasses}>
-                <li className={listClasses}><Link href={'/'}>{homeElement}</Link></li>
-                {pathNames.length > 0 && separator}
-            {
+            {paths !== "/" && (
+                  <>
+                    <li className={listClasses}><Link href={'/'}>{homeElement}</Link></li>
+                    {pathNames.length > 0 && separator}
+                  </>
+                )}
+                {
                 pathNames.map( (link, index) => {
                     let href = `/${pathNames.slice(0, index + 1).join('/')}`
                     let itemClasses = paths === href ? `${listClasses} ${activeClasses}` : listClasses

--- a/next/components/layout.tsx
+++ b/next/components/layout.tsx
@@ -43,11 +43,11 @@ export function Layout({ menus, children }: LayoutProps) {
           <Breadcrumb
           homeElement={'Home'}
           separator={<span>
-            <Chevron className="inline-block w-6 h-6" />
+            <Chevron className="w-6 h-6" />
               </span>}
           activeClasses='text-primary-600 dark:text-primary-200'
           containerClasses='flex pb-4' 
-          listClasses='hover:underline mx-2 font-bold'
+          listClasses='hover:underline mx-2'
           capitalizeLinks
         />
         {children}

--- a/next/components/layout.tsx
+++ b/next/components/layout.tsx
@@ -11,6 +11,8 @@ import { SkipToContentLink } from "@/ui/skip-to-content-link";
 import { Toaster } from "@/ui/toaster";
 import clsx from "clsx";
 import { useTranslation } from "next-i18next";
+import Breadcrumb from "./breadcrumb";
+import Chevron from "@/styles/icons/chevron-down.svg";
 
 export interface LayoutProps {
   menus: {
@@ -37,7 +39,19 @@ export function Layout({ menus, children }: LayoutProps) {
         </SkipToContentLink>
         <Header menu={menus.main} />
         <main className="grow bg-mischka" id="main-content">
-          <div className="mx-auto max-w-6xl px-6 py-8">{children}</div>
+          <div className="mx-auto max-w-6xl px-6 py-8">
+          <Breadcrumb
+          homeElement={'Home'}
+          separator={<span>
+          -
+              </span>}
+          activeClasses='text-primary-600'
+          containerClasses='flex py-5 bg-gradient-to-r from-purple-600 to-blue-600' 
+          listClasses='hover:underline mx-2 font-bold'
+          capitalizeLinks
+        />
+        {children}
+          </div>
 
         </main>
         <Toaster />

--- a/next/components/layout.tsx
+++ b/next/components/layout.tsx
@@ -45,7 +45,7 @@ export function Layout({ menus, children }: LayoutProps) {
           separator={<span>
             <Chevron className="inline-block w-6 h-6" />
               </span>}
-          activeClasses='text-primary-600'
+          activeClasses='text-primary-600 dark:text-primary-200'
           containerClasses='flex pb-4' 
           listClasses='hover:underline mx-2 font-bold'
           capitalizeLinks

--- a/next/components/layout.tsx
+++ b/next/components/layout.tsx
@@ -46,7 +46,7 @@ export function Layout({ menus, children }: LayoutProps) {
             <Chevron className="inline-block w-6 h-6" />
               </span>}
           activeClasses='text-primary-600'
-          containerClasses='flex py-5' 
+          containerClasses='flex pb-4' 
           listClasses='hover:underline mx-2 font-bold'
           capitalizeLinks
         />

--- a/next/components/layout.tsx
+++ b/next/components/layout.tsx
@@ -12,7 +12,7 @@ import { Toaster } from "@/ui/toaster";
 import clsx from "clsx";
 import { useTranslation } from "next-i18next";
 import Breadcrumb from "./breadcrumb";
-import Chevron from "@/styles/icons/chevron-down.svg";
+import Chevron from "@/styles/icons/chevron-right.svg";
 
 export interface LayoutProps {
   menus: {
@@ -43,10 +43,10 @@ export function Layout({ menus, children }: LayoutProps) {
           <Breadcrumb
           homeElement={'Home'}
           separator={<span>
-          -
+            <Chevron className="inline-block w-6 h-6" />
               </span>}
           activeClasses='text-primary-600'
-          containerClasses='flex py-5 bg-gradient-to-r from-purple-600 to-blue-600' 
+          containerClasses='flex py-5' 
           listClasses='hover:underline mx-2 font-bold'
           capitalizeLinks
         />

--- a/next/styles/icons/chevron-right.svg
+++ b/next/styles/icons/chevron-right.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" transform="rotate(270)"><g clip-path="url(#a)"><path fill="currentColor" d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41Z"/></g><defs><clipPath id="a"><path fill="#fff" d="M0 0h24v24H0z"/></clipPath></defs></svg>


### PR DESCRIPTION
## Link to ticket:

[Breadcrumbs](https://trello.com/c/vrYJJ982/38-pages-articles-bread-crumb-navigation)

## Changes proposed in this PR:

- breadcrumb component that renders the menu with its links based on the url path.
- new component imported into layout.tsx

## How to test:

1. git checkout breadCrumbNav
2. all pages should have the breadcrumb navigation working like magic


<img width="1138" alt="Screenshot 2023-11-24 at 14 40 27" src="https://github.com/BCH-Wunder-Project-team-4/Wunder.io/assets/121946942/0da2784f-5054-49eb-a773-975cca1b240d">

