### PR TITLE
All articles

### DIFF
--- a/drupal/config/sync/pathauto.pattern.article.yml
+++ b/drupal/config/sync/pathauto.pattern.article.yml
@@ -9,12 +9,12 @@ _core:
 id: article
 label: Article
 type: 'canonical_entities:node'
-pattern: 'articles/[node:title]'
+pattern: 'all-articles/[node:title]'
 selection_criteria:
-  2120d454-3901-4bfc-bf41-8c322b4b3759:
+  00380dc0-0f01-48fd-b0ff-6a92bceabdf0:
     id: 'entity_bundle:node'
     negate: false
-    uuid: 2120d454-3901-4bfc-bf41-8c322b4b3759
+    uuid: 00380dc0-0f01-48fd-b0ff-6a92bceabdf0
     context_mapping:
       node: node
     bundles:

--- a/drupal/config/sync/pathauto.pattern.events.yml
+++ b/drupal/config/sync/pathauto.pattern.events.yml
@@ -8,20 +8,20 @@ dependencies:
 id: events
 label: events
 type: 'canonical_entities:node'
-pattern: 'events/[node:title]'
+pattern: 'all-events/[node:title]'
 selection_criteria:
-  047f0306-1443-4f8d-99cc-f159ecc8436e:
+  a0de9f75-b463-4be7-8e5e-4d69b4780c25:
     id: 'entity_bundle:node'
     negate: false
-    uuid: 047f0306-1443-4f8d-99cc-f159ecc8436e
+    uuid: a0de9f75-b463-4be7-8e5e-4d69b4780c25
     context_mapping:
       node: node
     bundles:
       events: events
-  ce33bb50-ed90-4a5c-85ac-897383ef41d1:
+  b3c92aa1-90a4-41b2-ae1c-41cad33708af:
     id: language
     negate: false
-    uuid: ce33bb50-ed90-4a5c-85ac-897383ef41d1
+    uuid: b3c92aa1-90a4-41b2-ae1c-41cad33708af
     context_mapping:
       language: 'node:langcode:language'
     langcodes:

--- a/drupal/config/sync/pathauto.pattern.expert_talks.yml
+++ b/drupal/config/sync/pathauto.pattern.expert_talks.yml
@@ -9,12 +9,12 @@ _core:
 id: expert_talks
 label: 'Expert talks'
 type: 'canonical_entities:node'
-pattern: 'expertTalks/[node:title]'
+pattern: 'all-expertTalks/[node:title]'
 selection_criteria:
-  26cba523-67bb-4a3d-8f79-f79015557cda:
+  4b2d92b7-e5d8-4a07-af70-6e213d00d628:
     id: 'entity_bundle:node'
     negate: false
-    uuid: 26cba523-67bb-4a3d-8f79-f79015557cda
+    uuid: 4b2d92b7-e5d8-4a07-af70-6e213d00d628
     context_mapping:
       node: node
     bundles:

--- a/next/components/article-list-item.tsx
+++ b/next/components/article-list-item.tsx
@@ -29,7 +29,7 @@ export function ArticleListItem({ article }: ArticleListItemProps) {
       <h3 className="mb-2 line-clamp-2 text-heading-xs font-bold text-primary-600 dark:text-fog">
         {article.title}
       </h3>
-      <div className="mb-4 line-clamp-2 text-md text-scapaflow">
+      <div className="mb-4 line-clamp-2 text-md text-scapaflow dark:text-graysuit">
         {author && <>{t("posted-by", { author })} - </>}
         {date}
       </div>

--- a/next/components/events/eventList.tsx
+++ b/next/components/events/eventList.tsx
@@ -29,7 +29,7 @@ export function EventListItem({ event }: EventListItemProps) {
       <h3 className="mb-2 line-clamp-2 text-heading-xs font-bold text-primary-600 dark:text-fog">
         {event.title}
       </h3>
-      <div className="mb-4 line-clamp-2 text-md text-scapaflow">
+      <div className="mb-4 line-clamp-2 text-md text-scapaflow dark:text-graysuit">
         {date}
       </div>
       <div className="flex flex-col items-start gap-4 sm:flex-row">

--- a/next/components/events/eventList.tsx
+++ b/next/components/events/eventList.tsx
@@ -20,13 +20,13 @@ export function EventListItem({ event }: EventListItemProps) {
     <Link
       href={event.path.alias}
       className={classNames(
-        "relative mb-4 grid h-full rounded border  p-4 transition-all hover:shadow-md",
+        "relative mb-4 grid h-full rounded p-4 rounded-b-md border dark:border-scapaflow border-finnishwinter dark:bg-steelgray bg-mischka  transition-all hover:shadow-md  ",
         event.sticky
           ? "border-primary-100 bg-primary-50"
-          : "border-finnishwinter bg-white",
+          : "border-finnishwinter bg-mischka dark:bg-steelgray",
       )}
     >
-      <h3 className="mb-2 line-clamp-2 text-heading-xs font-bold">
+      <h3 className="mb-2 line-clamp-2 text-heading-xs font-bold text-primary-600 dark:text-fog">
         {event.title}
       </h3>
       <div className="mb-4 line-clamp-2 text-md text-scapaflow">

--- a/next/components/expertTalk/expertTalk-list-item.tsx
+++ b/next/components/expertTalk/expertTalk-list-item.tsx
@@ -26,7 +26,7 @@ export function ExpertTalkListItem({ expertTalk }: ExpertTalkListItemProps) {
       <h3 className="mb-2 line-clamp-2 text-heading-xs font-bold text-primary-600 dark:text-fog">
         {expertTalk.title}
       </h3>
-      <div className="mb-4 line-clamp-2 text-md text-scapaflow">
+      <div className="mb-4 line-clamp-2 text-md text-scapaflow dark:text-graysuit">
         {author && <>{t("posted-by", { author })} - </>}
       </div>
       <div className="flex flex-col items-start gap-4 sm:flex-row">

--- a/next/components/expertTalk/expertTalk-list-item.tsx
+++ b/next/components/expertTalk/expertTalk-list-item.tsx
@@ -17,13 +17,13 @@ export function ExpertTalkListItem({ expertTalk }: ExpertTalkListItemProps) {
     <Link
       href={expertTalk.path.alias}
       className={classNames(
-        "relative mb-4 grid h-full rounded border  p-4 transition-all hover:shadow-md",
+        "relative mb-4 grid h-full rounded p-4 rounded-b-md border dark:border-scapaflow border-finnishwinter dark:bg-steelgray bg-mischka  transition-all hover:shadow-md  ",
         expertTalk.sticky
           ? "border-primary-100 bg-primary-50"
-          : "border-finnishwinter bg-white",
+          : "border-finnishwinter bg-mischka dark:bg-steelgray",
       )}
     >
-      <h3 className="mb-2 line-clamp-2 text-heading-xs font-bold">
+      <h3 className="mb-2 line-clamp-2 text-heading-xs font-bold text-primary-600 dark:text-fog">
         {expertTalk.title}
       </h3>
       <div className="mb-4 line-clamp-2 text-md text-scapaflow">

--- a/next/pages/all-articles/index..tsx
+++ b/next/pages/all-articles/index..tsx
@@ -43,15 +43,6 @@ export default function AllArticlesPage({
           </li>
         ))}
       </ul>
-      <div>
-        <button className={clsx(
-          buttonVariants({ variant: "primary" }),
-          "text-base mr-4 mt-4 inline-flex px-5 py-3",
-        )}
-        >
-          {t("load-more")}
-          <ArrowIcon aria-hidden className="ml-3 h-6 w-6 -rotate-90" /></button>
-      </div>
     </>
   );
 }

--- a/next/pages/all-articles/index..tsx
+++ b/next/pages/all-articles/index..tsx
@@ -2,12 +2,11 @@ import {
   ArticleTeaser as ArticleTeaserType,
   validateAndCleanupArticleTeaser,
 } from "@/lib/zod/article-teaser";
-import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from "next";
+import { GetStaticProps, InferGetStaticPropsType } from "next";
 import {
   LanguageLinks,
   createLanguageLinksForNextOnlyPage,
 } from "@/lib/contexts/language-links-context";
-import { Pagination, PaginationProps } from "@/components/pagination";
 
 import { ArticleListItem } from "@/components/article-list-item";
 import { HeadingPage } from "@/components/heading--page";
@@ -17,9 +16,6 @@ import { getCommonPageProps } from "@/lib/get-common-page-props";
 import { getLatestArticlesItems } from "@/lib/drupal/get-articles";
 import { useRef } from "react";
 import { useTranslation } from "next-i18next";
-import { buttonVariants } from "@/ui/button";
-import clsx from "clsx";
-import ArrowIcon from "@/styles/icons/arrow-down.svg";
 
 interface AllArticlesPageProps extends LayoutProps {
   articleTeasers: ArticleTeaserType[];

--- a/next/pages/all-events/index.tsx
+++ b/next/pages/all-events/index.tsx
@@ -4,15 +4,12 @@ import {
   LanguageLinks,
   createLanguageLinksForNextOnlyPage,
 } from "@/lib/contexts/language-links-context";
-import { useEffect, useRef, useState } from "react";
+import { useRef} from "react";
 
-import ArrowIcon from "@/styles/icons/arrow-down.svg";
 import { EventListItem } from "@/components/events/eventList";
 import { HeadingPage } from "@/components/heading--page";
 import { LayoutProps } from "@/components/layout";
 import { Meta } from "@/components/meta";
-import { buttonVariants } from "@/ui/button";
-import clsx from "clsx";
 import { getCommonPageProps } from "@/lib/get-common-page-props";
 import { getLatestEventsItems } from "@/lib/drupal/get-events";
 import { useRouter } from "next/router";
@@ -43,27 +40,16 @@ export default function AllEventsPage({
 
         ))}
       </ul>
-      <div>
-        <button className={clsx(
-          buttonVariants({ variant: "primary" }),
-          "text-base mr-4 mt-4 inline-flex px-5 py-3",
-        )}
-        >
-          {t("load-more")}
-          <ArrowIcon aria-hidden className="ml-3 h-6 w-6 -rotate-90" /></button>
-      </div>
     </>
   );
 }
-
-
 
 export const getStaticProps: GetStaticProps<AllEventsPageProps> = async (
   context,
 ) => {
   console.log("context", context);
 
-  const pageRoot = "/contact";
+  const pageRoot = "/all-events";
   const languageLinks = createLanguageLinksForNextOnlyPage(pageRoot, context);
   const { events } = await getLatestEventsItems({
     locale: context.locale

--- a/next/pages/all-events/index.tsx
+++ b/next/pages/all-events/index.tsx
@@ -32,7 +32,7 @@ export default function AllEventsPage({
 
   return (
     <>
-      <Meta title={"All Expert Talks"} metatags={[]} />
+      <Meta title={"All Events"} metatags={[]} />
       <div ref={focusRef} tabIndex={-1} />
       <HeadingPage>All Expert Talks</HeadingPage>
       <ul className="mt-4">

--- a/next/pages/all-events/index.tsx
+++ b/next/pages/all-events/index.tsx
@@ -29,9 +29,9 @@ export default function AllEventsPage({
 
   return (
     <>
-      <Meta title={"All Events"} metatags={[]} />
+      <Meta title={t("all-events")} metatags={[]} />
       <div ref={focusRef} tabIndex={-1} />
-      <HeadingPage>All Expert Talks</HeadingPage>
+      <HeadingPage>{t("all-events")}</HeadingPage>
       <ul className="mt-4">
         {eventTeasers?.map((event) => (
           <li key={event.id}>

--- a/next/pages/all-expertTalks/index.tsx
+++ b/next/pages/all-expertTalks/index.tsx
@@ -16,9 +16,6 @@ import { getCommonPageProps } from "@/lib/get-common-page-props";
 import { getLatestExpertTalksItems } from "@/lib/drupal/get-expertTalks";
 import { useRef } from "react";
 import { useTranslation } from "next-i18next";
-import { buttonVariants } from "@/ui/button";
-import clsx from "clsx";
-import ArrowIcon from "@/styles/icons/arrow-down.svg";
 
 interface AllExpertTalksPageProps extends LayoutProps {
   expertTalkTeasers: ExpertTalkTeaserType[];
@@ -42,15 +39,6 @@ export default function AllExpertTalksPage({
           </li>
         ))}
       </ul>
-      <div>
-        <button className={clsx(
-          buttonVariants({ variant: "primary" }),
-          "text-base mr-4 mt-4 inline-flex px-5 py-3",
-        )}
-        >
-          {t("load-more")}
-          <ArrowIcon aria-hidden className="ml-3 h-6 w-6 -rotate-90" /></button>
-      </div>
     </>
   );
 }

--- a/next/pages/index.tsx
+++ b/next/pages/index.tsx
@@ -6,10 +6,8 @@ import { ExpertTalkTeaser, validateAndCleanupExpertTalkTeaser } from "@/lib/zod/
 import { Frontpage, validateAndCleanupFrontpage } from "@/lib/zod/frontpage";
 import { GetStaticProps, InferGetStaticPropsType } from "next";
 
-import { Divider } from "@/ui/divider";
 import { DrupalNode } from "next-drupal";
 import { LayoutProps } from "@/components/layout";
-import { LogoStrip } from "@/components/logo-strip";
 import { Meta } from "@/components/meta";
 import { Paragraph } from "@/components/paragraph";
 import { drupal } from "@/lib/drupal/drupal-client";
@@ -28,9 +26,6 @@ interface IndexPageProps extends LayoutProps {
 
 export default function IndexPage({
   frontpage,
-  promotedArticleTeasers,
-  promotedExpertTalkTeasers,
-  eventsTeasers,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   const { t } = useTranslation();
 
@@ -43,8 +38,6 @@ export default function IndexPage({
           <Paragraph paragraph={paragraph} key={paragraph.id} />
         ))}
       </div>
-      <Divider className="max-w-4xl" />
-      <LogoStrip />
     </>
   );
 }

--- a/next/public/locales/en/common.json
+++ b/next/public/locales/en/common.json
@@ -107,5 +107,8 @@
   "Accessibility": "Accessibility",
   "Cookie Settings": "Cookie Settings",
   "footer-newsletter-terms": "I approve that Wunder processes my personal data according to its",
-  "form-subscribe": "Subscribe"
+  "form-subscribe": "Subscribe",
+  "all-events": "All events",
+  "all-expertTalks": "All expert talks"
+
 }

--- a/next/public/locales/fi/common.json
+++ b/next/public/locales/fi/common.json
@@ -107,5 +107,7 @@
   "Accessibility": "Saavutettavuus",
   "Cookie Settings": "Evästeasetukset",
   "footer-newsletter-terms": "Hyväksyn, että Wunder käsittelee henkilökohtaisia tietojani sen ",
-  "form-subsribe": "Tilaa"
+  "form-subsribe": "Tilaa",
+  "all-events": "Kaikki tapahtumat",
+  "all-expertTalks": "Kaikki asiantuntijapuheet"
 }


### PR DESCRIPTION
## Link to ticket:

[Ticket](https://trello.com/c/WsFzioFD/121-all-articles-and-expert-talks-into-static-pages)

## Changes proposed in this PR:

- turned all-articles and all-expertTalks into static pages instead of dynamic
- added translations for their titles
- changed auto path patterns for articles, events and expert talks

## How to test:

1. git fetch origin allArticles
2. lando drush cim
3. add new article, event and expert talk content.
4. Navigate to them. Now the breadcrumb of 'all-articles' or 'all-expertTalks' should take to the correct pages.

## Video

https://github.com/BCH-Wunder-Project-team-4/Wunder.io/assets/121946942/618bcc3c-c92d-4571-a8b0-fd970dc9fff3



