### PR TITLE
Change expert job title text color to scapaflow for better contrast

### DIFF
--- a/next/components/expertTalk/expertTalk-list-item.tsx
+++ b/next/components/expertTalk/expertTalk-list-item.tsx
@@ -1,9 +1,9 @@
-import { ExpertTalkTeaser } from "@/lib/zod/expertTalk-teaser";
-import Image from "next/image";
-import Link from "next/link";
 import { absoluteUrl } from "@/lib/drupal/absolute-url";
+import { ExpertTalkTeaser } from "@/lib/zod/expertTalk-teaser";
 import classNames from "classnames";
 import { useTranslation } from "next-i18next";
+import Image from "next/image";
+import Link from "next/link";
 
 interface ExpertTalkListItemProps {
   expertTalk: ExpertTalkTeaser;
@@ -37,7 +37,7 @@ export function ExpertTalkListItem({ expertTalk }: ExpertTalkListItemProps) {
         )}
         <div className="flex flex-col py-2 px-5">
           <p className="font-bold text-md">{expertTalk.field_name}</p>
-          <p className="italic text-stone dark:text-finnishwinter">{expertTalk.field_expert_job_title}</p>
+          <p className="italic text-scapaflow dark:text-finnishwinter">{expertTalk.field_expert_job_title}</p>
         </div>
       </div>
       <p className="text-lg font-bold line-clamp-2 text-primary-600 dark:text-fog">{expertTalk.title}</p>

--- a/next/components/expertTalk/expertTalk-teaser.tsx
+++ b/next/components/expertTalk/expertTalk-teaser.tsx
@@ -1,9 +1,8 @@
+import { absoluteUrl } from "@/lib/drupal/absolute-url";
 import { ExpertTalkTeaser as ExpertTalkTeaserType } from "@/lib/zod/expertTalk-teaser";
+import { useTranslation } from "next-i18next";
 import Image from "next/image";
 import Link from "next/link";
-import { absoluteUrl } from "@/lib/drupal/absolute-url";
-import { useRouter } from "next/router";
-import { useTranslation } from "next-i18next";
 
 interface ExpertTalkTeaserProps {
   expertTalk: ExpertTalkTeaserType;
@@ -33,7 +32,7 @@ export function ExpertTalkTeaser({ expertTalk }: ExpertTalkTeaserProps) {
         <div className="flex flex-col py-2 px-5">
 
           <p className="font-bold text-md">{expertTalk.field_name}</p>
-          <p className="italic text-stone dark:text-finnishwinter">{expertTalk.field_expert_job_title}</p>
+          <p className="italic text-scapaflow dark:text-finnishwinter">{expertTalk.field_expert_job_title}</p>
         </div>
       </div>
       <p className="text-lg font-bold line-clamp-2 text-primary-600 dark:text-fog">{expertTalk.title}</p>


### PR DESCRIPTION
## Link to ticket:

Fixes #48

## Changes proposed in this PR:

Fixes the color contrast issue detailed in #48. Changes `text-stone` to `text-scapaflow` in light mode for Expert Talk card job title so that it will pass the color contrast check for normal text.

Result:
<img width="422" alt="Screenshot 2023-12-15 at 19 39 28" src="https://github.com/BCH-Wunder-Project-team-4/Wunder.io/assets/122397061/5a9d94c4-ba1f-4b7d-bfc9-331d5dfa1f1b">

## How to test:

1. `git fetch fix-expertJobTitle-color`
2. `git checkout fix-expertJobTitle-color`
3. Check Lighthouse for both frontpage (add Expert talk listing if there isn't yet) and All Expert Talks page. There shouldn't be any Accessibility issues regarding text color contrast now.

## Best practices:

<details>
<summary><h3>Accessibility:</h3></summary>
<p>
This project must support WCAG accessibility level AA <em>(edit this according to the requirements of your project)</em>. To ensure this standard is met, remember to:

- Perform automated checks using a tool such as Wave or SiteImprove.
- Test keyboard navigation: are all parts of the UI navigable using only the keyboard? Is the tab order logical? Can popups, menus etc be dismissed with the escape key?
- Test responsiveness, scaling and text reflow.
- Make sure no accessibility issues exist on either desktop or mobile views.
- If you have time, test with a screen reader such as VoiceOver (macOS), NVDA (Windows), or Orca (Linux).

Use the [Accessibility Testing Cheat Sheet](https://intra.wunder.io/info/accessibility-group/accessibility-testing-cheat-sheet) for information on how to run these tests.
</p>
</details>
