### PR TITLE
styling for expert talk page

### DIFF
--- a/next/components/expertTalk/expertTalk.tsx
+++ b/next/components/expertTalk/expertTalk.tsx
@@ -16,38 +16,57 @@ export function ExpertTalk({ expertTalk, ...props }: ExpertTalkProps) {
   return (
     <article {...props}>
       <HeadingPage>{expertTalk.title}</HeadingPage>
-      {expertTalk.field_excerpt && (
-        <div className="my-4 text-xl">{expertTalk.field_excerpt}</div>
-      )}
-      <div className="mb-4 text-scapaflow">
-        {expertTalk.uid?.display_name && (
-          <span>
-            {t("posted-by", { author: expertTalk.field_name })} -{" "}
-          </span>
+
+      <div className="flex flex-row items-center my-5">
+
+        {expertTalk.field_image && (
+
+          <Image
+            src={absoluteUrl(expertTalk.field_experts_photo.uri.url)}
+            width={300}
+            height={300}
+            alt={expertTalk.field_experts_photo.resourceIdObjMeta.alt}
+            className="h-20 w-20 object-cover rounded-full "
+          />
+
+        )}
+        <div className="flex flex-col py-2 px-5">
+
+          <p className="font-bold text-lg">{expertTalk.field_name}</p>
+          <p className="italic text-md text-scapaflow dark:text-finnishwinter">{expertTalk.field_expert_job_title}</p>
+        </div>
+      </div>
+      <div className="flex flex-col md:flex-row mt-7 mb-12 items-center">
+
+        {expertTalk.field_excerpt && (
+          <div className="my-4 text-xl md:w-1/2 pr-10  ">
+            <h2 className="first-letter:float-left first-letter:text-heading-xl md:first-letter:text-heading-2xl first-letter:px-4 first-letter:text-primary-600 dark:first-letter:text-fog">{expertTalk.field_excerpt}</h2> </div>
         )}
 
+        {expertTalk.field_image && (
+          <figure>
+            <Image
+              src={absoluteUrl(expertTalk.field_image.uri.url)}
+              width={768}
+              height={480}
+              style={{ width: 768, height: 480 }}
+              alt={expertTalk.field_image.resourceIdObjMeta.alt}
+              className="object-contain md:w-2/5 "
+              priority
+            />
+            {expertTalk.field_image.resourceIdObjMeta.title && (
+              <figcaption className="py-2 text-center text-sm text-steelgray ">
+                {expertTalk.field_image.resourceIdObjMeta.title}
+              </figcaption>
+            )}
+          </figure>
+        )}
       </div>
-      {expertTalk.field_image && (
-        <figure>
-          <Image
-            src={absoluteUrl(expertTalk.field_image.uri.url)}
-            width={768}
-            height={480}
-            style={{ width: 768, height: 480 }}
-            alt={expertTalk.field_image.resourceIdObjMeta.alt}
-            className="object-cover"
-            priority
-          />
-          {expertTalk.field_image.resourceIdObjMeta.title && (
-            <figcaption className="py-2 text-center text-sm text-steelgray">
-              {expertTalk.field_image.resourceIdObjMeta.title}
-            </figcaption>
-          )}
-        </figure>
-      )}
+
+
       {expertTalk.body?.processed && (
         <FormattedText
-          className="mt-4 text-md/xl text-steelgray dark:text-mischka sm:text-lg"
+          className={expertTalk.body.processed.length > 700 ? "mt-4 text-md/xl text-steelgray dark:text-mischka sm:text-lg columns-2" : "mt-4 text-md/xl text-steelgray dark:text-mischka sm:text-lg"}
           html={expertTalk.body?.processed}
         />
       )}

--- a/next/components/expertTalk/expertTalk.tsx
+++ b/next/components/expertTalk/expertTalk.tsx
@@ -66,7 +66,7 @@ export function ExpertTalk({ expertTalk, ...props }: ExpertTalkProps) {
 
       {expertTalk.body?.processed && (
         <FormattedText
-          className={expertTalk.body.processed.length > 700 ? "mt-4 text-md/xl text-steelgray dark:text-mischka sm:text-lg columns-2" : "mt-4 text-md/xl text-steelgray dark:text-mischka sm:text-lg"}
+          className={expertTalk.body.processed.length > 700 ? "mt-4 text-md/xl text-steelgray dark:text-mischka sm:text-lg md:columns-2 columns-1" : "mt-4 text-md/xl text-steelgray dark:text-mischka sm:text-lg"}
           html={expertTalk.body?.processed}
         />
       )}


### PR DESCRIPTION
## Link to ticket:

#59 

## Link to feature environment:

http://localhost:3000/all-expertTalks/unleashing-power-react-hooks

## Changes proposed in this PR:

Styling for expert talk page

<img width="1192" alt="Screenshot 2023-12-19 at 17 09 35" src="https://github.com/BCH-Wunder-Project-team-4/Wunder.io/assets/117649417/c5b162d7-865c-4049-a3ee-916b6e948e33">


## How to test:

1. `git fetch origin  issue59ExpertTalk`
2. `git checkout issue59ExpertTalk`
3. go to http://localhost:3000/all-expertTalks/unleashing-power-react-hooks or any other expert talk 

## Best practices:

<details>
<summary><h3>Accessibility:</h3></summary>
<p>
This project must support WCAG accessibility level AA <em>(edit this according to the requirements of your project)</em>. To ensure this standard is met, remember to:

- Perform automated checks using a tool such as Wave or SiteImprove.
- Test keyboard navigation: are all parts of the UI navigable using only the keyboard? Is the tab order logical? Can popups, menus etc be dismissed with the escape key?
- Test responsiveness, scaling and text reflow.
- Make sure no accessibility issues exist on either desktop or mobile views.
- If you have time, test with a screen reader such as VoiceOver (macOS), NVDA (Windows), or Orca (Linux).

Use the [Accessibility Testing Cheat Sheet](https://intra.wunder.io/info/accessibility-group/accessibility-testing-cheat-sheet) for information on how to run these tests.
</p>
</details>
